### PR TITLE
Using hdiapi instead of libusb for compatible in Mac OSX. Tested in 1…

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ INSTALL = /usr/bin/install -c
 INSTALLDATA = /usr/bin/install -c -m 644
 PROGNAME = footswitch
 CFLAGS = -Wall
-LDFLAGS = -lusb-1.0
+LDFLAGS = -lhidapi
 
 all: $(PROGNAME)
 

--- a/debug.c
+++ b/debug.c
@@ -20,7 +20,6 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 */
 #include <stdio.h>
-#include <libusb-1.0/libusb.h>
 #include "debug.h"
 
 void debug_arr(unsigned char data[], int length) {
@@ -30,39 +29,3 @@ void debug_arr(unsigned char data[], int length) {
     }
     printf("\n");
 }
-
-char* libusb_err(int rc) {
-    switch (rc) {
-        case LIBUSB_SUCCESS:
-            return "LIBUSB_SUCCESS";
-        case LIBUSB_ERROR_IO:
-            return "LIBUSB_ERROR_IO";
-        case LIBUSB_ERROR_INVALID_PARAM:
-            return "LIBUSB_ERROR_INVALID_PARAM";
-        case LIBUSB_ERROR_ACCESS:
-            return "LIBUSB_ERROR_ACCESS";
-        case LIBUSB_ERROR_NO_DEVICE:
-            return "LIBUSB_ERROR_NO_DEVICE";
-        case LIBUSB_ERROR_NOT_FOUND:
-            return "LIBUSB_ERROR_NOT_FOUND";
-        case LIBUSB_ERROR_BUSY:
-            return "LIBUSB_ERROR_BUSY";
-        case LIBUSB_ERROR_TIMEOUT:
-            return "LIBUSB_ERROR_TIMEOUT";
-        case LIBUSB_ERROR_OVERFLOW:
-            return "LIBUSB_ERROR_OVERFLOW";
-        case LIBUSB_ERROR_PIPE:
-            return "LIBUSB_ERROR_PIPE";
-        case LIBUSB_ERROR_INTERRUPTED:
-            return "LIBUSB_ERROR_INTERRUPTED";
-        case LIBUSB_ERROR_NO_MEM:
-            return "LIBUSB_ERROR_NO_MEM";
-        case LIBUSB_ERROR_NOT_SUPPORTED:
-            return "LIBUSB_ERROR_NOT_SUPPORTED";
-        case LIBUSB_ERROR_OTHER:
-            return "LIBUSB_ERROR_OTHER";
-        default:
-            return "UNKNOWN";
-    }
-}
-

--- a/debug.h
+++ b/debug.h
@@ -28,9 +28,6 @@ THE SOFTWARE.
     exit(1); \
     }
 
-// according to the docs there should be libusb_error_name() but it is missing
-char* libusb_err(int rc);
-
 void debug_arr(unsigned char data[], int length);
 
 #endif


### PR DESCRIPTION
Using hdiapi instead of libusb for compatible in Mac OSX. Tested in 10.10 Yosemite.

Currently there's no working solution in Mac OSX to claim ownership due to kernel extension, this change might help.