### PR TITLE
Update 19-footswitch.rules to be able to use the tool as regular user

### DIFF
--- a/19-footswitch.rules
+++ b/19-footswitch.rules
@@ -1,4 +1,4 @@
-ATTR{product}=="FootSwitchV1.1"\
+ATTR{product}=="FootSwitch*"\
 MODE:="0666"\
 GROUP="hid"\
 RUN+="keymap $name 0x70066 screenlock"\


### PR DESCRIPTION
To make UDEV-rules work on Ubuntu to be able to run the tool as regular user.
Tested on Ubuntu 14.04.5
