### PR TITLE
Adding alternate PID.

### DIFF
--- a/common.h
+++ b/common.h
@@ -24,7 +24,8 @@ THE SOFTWARE.
 
 
 #define VID 0x0C45
-#define PID 0x7403
+#define PID3 0x7403
+#define PID4 0x7404
 
 enum modifier {
     CTRL = 1,

--- a/footswitch.c
+++ b/footswitch.c
@@ -72,14 +72,14 @@ void usage() {
     exit(1);
 }
 
-void init() {
+void init_pid(unsigned short pid) {
 #ifdef OSX
     hid_init();
-    dev = hid_open(VID, PID, NULL);
+    dev = hid_open(VID, pid, NULL);
 #else
     struct hid_device_info *info = NULL, *ptr = NULL;
     hid_init();
-    info = hid_enumerate(VID, PID);
+    info = hid_enumerate(VID, pid);
     ptr = info;
     while (ptr != NULL) {
         if (ptr->interface_number == 1) {
@@ -90,8 +90,15 @@ void init() {
     }
     hid_free_enumeration(info);
 #endif
+}
+
+void init() {
+    init_pid(PID3);
     if (dev == NULL) {
-        fatal("cannot find footswitch with VID:PID=%x:%x", VID, PID);
+        init_pid(PID4);
+    }
+    if (dev == NULL) {
+        fatal("Cannot find footswitch with VID:PID=%x:%x or VID:PID=%x:%x", VID, PID3, VID, PID4);
     }
 }
 
@@ -453,6 +460,7 @@ void write_pedals() {
     }
     */
     usb_write(pd.start);
+    usleep(1000*1000);
     write_pedal(&pd.pedals[0]);
     write_pedal(&pd.pedals[1]);
     write_pedal(&pd.pedals[2]);


### PR DESCRIPTION
I have just bought a triple pedal from Ebay, and it reports the PID as 7404.  Basically nothing else needs changing.  (USBPcap report start[3] as 01, but 00 works just fine.)

The additional sleep is that the following usb_write() fails for me otherwise with the error message "((null))".