### PR TITLE
Use the built-in generic C build rules

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,19 +4,19 @@ CFLAGS = -Wall
 UNAME := $(shell uname)
 ifeq ($(UNAME), Darwin)
 	CFLAGS += -DOSX $(shell pkg-config --cflags hidapi)
-	LDFLAGS = $(shell pkg-config --libs hidapi)
+	LDLIBS = $(shell pkg-config --libs hidapi)
 else
 	ifeq ($(UNAME), Linux)
 		CFLAGS += $(shell pkg-config --cflags hidapi-libusb)
-		LDFLAGS = $(shell pkg-config --libs hidapi-libusb)
+		LDLIBS = $(shell pkg-config --libs hidapi-libusb)
 	else
-		LDFLAGS = -lhidapi
+		LDLIBS = -lhidapi
 	endif
 endif
 
 all: scythe.c footswitch.c common.h common.c debug.h debug.c
-	$(CC) footswitch.c common.c debug.c -o footswitch $(CFLAGS) $(LDFLAGS)
-	$(CC) scythe.c common.c debug.c -o scythe $(CFLAGS) $(LDFLAGS)
+	$(CC) footswitch.c common.c debug.c -o footswitch $(CFLAGS) $(LDLIBS)
+	$(CC) scythe.c common.c debug.c -o scythe $(CFLAGS) $(LDLIBS)
 
 install: all
 	$(INSTALL) footswitch /usr/local/bin

--- a/Makefile
+++ b/Makefile
@@ -14,9 +14,10 @@ else
 	endif
 endif
 
-all: scythe.c footswitch.c common.h common.c debug.h debug.c
-	$(CC) footswitch.c common.c debug.c -o footswitch $(CFLAGS) $(LDLIBS)
-	$(CC) scythe.c common.c debug.c -o scythe $(CFLAGS) $(LDLIBS)
+all: footswitch scythe
+
+footswitch: footswitch.c common.c debug.c
+scythe: scythe.c common.c debug.c
 
 install: all
 	$(INSTALL) footswitch /usr/local/bin


### PR DESCRIPTION
These are almost always more correct in terms of being "standard", properly accepting the flags, etc. For instance they correctly use both `LDFLAGS` and `LDLIBS`, see #45.