### PR TITLE
Adding device ID for another PCSensor footswitch

### DIFF
--- a/footswitch.c
+++ b/footswitch.c
@@ -97,6 +97,7 @@ void init() {
         {0x0c45, 0x7403},
         {0x0c45, 0x7404},
         {0x413d, 0x2107},
+        {0x1a86, 0xe026},
     };
     int i = 0;
     for (i = 0 ; i < sizeof(vid_pid) / sizeof(vid_pid[0]) ; i++) {


### PR DESCRIPTION
I tested the device and both reading current config and adding new keys seem to work correctly.