### PR TITLE
Add support of right side modifier keys.

### DIFF
--- a/common.c
+++ b/common.c
@@ -184,7 +184,9 @@ static const keymap_entry keymap[] =
     {"XF86AudioRaiseVolume", 0x80},
     {"XF86AudioLowerVolume", 0x81},
     {"<82>",        0x82},
+    {"Hangul",      0x82},
     {"<83>",        0x83},
+    {"Hangul_Hanja",0x83},
     {"A",           0x84},
     {"B",           0x85},
     {"C",           0x86},
@@ -325,6 +327,30 @@ Bool parse_modifier(const char *arg, enum modifier *mod) {
         return 1;
     } else if (strcasecmp("shift", arg) == 0) {
         *mod = SHIFT;
+        return 1;
+    } else if (strcasecmp("l_ctrl", arg) == 0) {
+        *mod = CTRL;
+        return 1;
+    } else if (strcasecmp("l_alt", arg) == 0) {
+        *mod = ALT;
+        return 1;
+    } else if (strcasecmp("l_win", arg) == 0) {
+        *mod = WIN;
+        return 1;
+    } else if (strcasecmp("l_shift", arg) == 0) {
+        *mod = SHIFT;
+        return 1;
+    }  else if (strcasecmp("r_ctrl", arg) == 0) {
+        *mod = R_CTRL;
+        return 1;
+    } else if (strcasecmp("r_alt", arg) == 0) {
+        *mod = R_ALT;
+        return 1;
+    } else if (strcasecmp("r_win", arg) == 0) {
+        *mod = R_WIN;
+        return 1;
+    } else if (strcasecmp("r_shift", arg) == 0) {
+        *mod = R_SHIFT;
         return 1;
     }
     return 0;

--- a/common.h
+++ b/common.h
@@ -27,6 +27,10 @@ enum modifier {
     SHIFT = 2,
     ALT = 4,
     WIN = 8,
+    R_CTRL = 16,
+    R_SHIFT = 32,
+    R_ALT = 64,
+    R_WIN = 128,
 };
 
 enum mouse_button {

--- a/footswitch.c
+++ b/footswitch.c
@@ -63,7 +63,7 @@ void usage() {
         "   -S rstring  - append the specified raw string (hex numbers delimited with spaces)\n"
         "   -a key      - append the specified key\n"
         "   -k key      - write the specified key\n"
-        "   -m modifier - ctrl|shift|alt|win\n"
+        "   -m modifier - (l_,r_)ctrl|shift|alt|win\n"
         "   -b button   - mouse_left|mouse_middle|mouse_right\n"
         "   -x X        - move the mouse cursor horizontally by X pixels\n"
         "   -y Y        - move the mouse cursor vertically by Y pixels\n"
@@ -168,16 +168,28 @@ void print_mouse(unsigned char data[]) {
 void print_key(unsigned char data[]) {
     char combo[128] = {0};
     if ((data[2] & CTRL) != 0) {
-        strcat(combo, "ctrl+");
+        strcat(combo, "l_ctrl+");
     }
     if ((data[2] & SHIFT) != 0) {
-        strcat(combo, "shift+");
+        strcat(combo, "l_shift+");
     }
     if ((data[2] & ALT) != 0) {
-        strcat(combo, "alt+");
+        strcat(combo, "l_alt+");
     }
     if ((data[2] & WIN) != 0) {
-        strcat(combo, "win+");
+        strcat(combo, "l_win+");
+    }
+    if ((data[2] & R_CTRL) != 0) {
+        strcat(combo, "r_ctrl+");
+    }
+    if ((data[2] & R_SHIFT) != 0) {
+        strcat(combo, "r_shift+");
+    }
+    if ((data[2] & R_ALT) != 0) {
+        strcat(combo, "r_alt+");
+    }
+    if ((data[2] & R_WIN) != 0) {
+        strcat(combo, "r_win+");
     }
     if (data[3] != 0) {
         const char *key = decode_byte(data[3]);


### PR DESCRIPTION
On Linux, using xkb, r_ctrl can be used as the Multikey and r_alt can be used as the ISO Level 3 shift modifier. For this reason, it is necessary to distinguish the left and right modifer keys.

Eventually, you can type <dead_key> through this code and keyboard layout setup.

In my setup, when I press AltGr (Iso Level 3 shift) + g, <dead_greek> is typed. If I want to print <greek_alpha>, I put AltGr (Iso Level3 shift) + g on the pedal, press the pedal and then press the 'a' key.

And the code for the <82> <83> key, which is a slight change, is for Korean keyboard users.
