### PR TITLE
Modified Makefile to allow staged install and packaging for linux distros

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,9 +21,11 @@ footswitch: footswitch.c common.c debug.c
 scythe: scythe.c common.c debug.c
 
 install: all
-	$(INSTALL) footswitch -D $(DESTDIR)$(PREFIX)/bin/
-	$(INSTALL) scythe -D $(DESTDIR)$(PREFIX)/bin/
+	$(INSTALL) -d $(DESTDIR)$(PREFIX)/bin
+	$(INSTALL) footswitch $(DESTDIR)$(PREFIX)/bin
+	$(INSTALL) scythe $(DESTDIR)$(PREFIX)/bin
 ifeq ($(UNAME), Linux)
+	$(INSTALL) -d $(DESTDIR)$(PREFIX)/etc/udev/rules.d
 	$(INSTALLDATA) 19-footswitch.rules -D $(DESTDIR)/etc/udev/rules.d
 endif
 

--- a/Makefile
+++ b/Makefile
@@ -21,8 +21,8 @@ footswitch: footswitch.c common.c debug.c
 scythe: scythe.c common.c debug.c
 
 install: all
-	$(INSTALL) footswitch $(DESTDIR)$(PREFIX)/bin
-	$(INSTALL) scythe $(DESTDIR)$(PREFIX)/bin
+	$(INSTALL) footswitch $(DESTDIR)$(PREFIX)/bin/
+	$(INSTALL) scythe $(DESTDIR)$(PREFIX)/bin/
 ifeq ($(UNAME), Linux)
 	$(INSTALLDATA) 19-footswitch.rules $(DESTDIR)/etc/udev/rules.d
 endif

--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,5 @@
-# PREFIX = /usr/local
-PREFIX = /usr
-# UDEVPREFIX = /etc/udev
-UDEVPREFIX = /lib/udev
-
+PREFIX = /usr/local
+UDEVPREFIX = /etc/udev
 
 INSTALL = /usr/bin/install -c
 INSTALLDATA = /usr/bin/install -c -m 644

--- a/Makefile
+++ b/Makefile
@@ -26,7 +26,7 @@ install: all
 	$(INSTALL) scythe $(DESTDIR)$(PREFIX)/bin
 ifeq ($(UNAME), Linux)
 	$(INSTALL) -d $(DESTDIR)$(PREFIX)/etc/udev/rules.d
-	$(INSTALLDATA) 19-footswitch.rules -D $(DESTDIR)/etc/udev/rules.d
+	$(INSTALLDATA) 19-footswitch.rules $(DESTDIR)/etc/udev/rules.d
 endif
 
 uninstall:

--- a/Makefile
+++ b/Makefile
@@ -25,7 +25,7 @@ install: all
 	$(INSTALL) footswitch $(DESTDIR)$(PREFIX)/bin
 	$(INSTALL) scythe $(DESTDIR)$(PREFIX)/bin
 ifeq ($(UNAME), Linux)
-	$(INSTALL) -d $(DESTDIR)$(PREFIX)/etc/udev/rules.d
+	$(INSTALL) -d $(DESTDIR)/etc/udev/rules.d
 	$(INSTALLDATA) 19-footswitch.rules $(DESTDIR)/etc/udev/rules.d
 endif
 

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 PREFIX = /usr/local
-INSTALL = /usr/bin/install -cd
-INSTALLDATA = /usr/bin/install -cd -m 644
+INSTALL = /usr/bin/install -c
+INSTALLDATA = /usr/bin/install -c -m 644
 CFLAGS = -Wall
 UNAME := $(shell uname)
 ifeq ($(UNAME), Darwin)
@@ -21,13 +21,13 @@ footswitch: footswitch.c common.c debug.c
 scythe: scythe.c common.c debug.c
 
 install: all
-	$(INSTALL) footswitch $(DESTDIR)$(PREFIX)/bin/
-	$(INSTALL) scythe $(DESTDIR)$(PREFIX)/bin/
+	$(INSTALL) footswitch -D $(DESTDIR)$(PREFIX)/bin/
+	$(INSTALL) scythe -D $(DESTDIR)$(PREFIX)/bin/
 ifeq ($(UNAME), Linux)
-	$(INSTALLDATA) 19-footswitch.rules $(DESTDIR)/etc/udev/rules.d
+	$(INSTALLDATA) 19-footswitch.rules -D $(DESTDIR)/etc/udev/rules.d
 endif
 
-uninstall: 
+uninstall:
 	rm -f $(DESTDIR)$(PREFIX)/bin/footswitch
 	rm -f $(DESTDIR)$(PREFIX)/bin/scythe
 ifeq ($(UNAME), Linux)

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 PREFIX = /usr/local
-INSTALL = /usr/bin/install -cD
-INSTALLDATA = /usr/bin/install -cD -m 644
+INSTALL = /usr/bin/install -cd
+INSTALLDATA = /usr/bin/install -cd -m 644
 CFLAGS = -Wall
 UNAME := $(shell uname)
 ifeq ($(UNAME), Darwin)

--- a/Makefile
+++ b/Makefile
@@ -35,7 +35,7 @@ uninstall:
 	rm -f $(DESTDIR)$(PREFIX)/bin/footswitch
 	rm -f $(DESTDIR)$(PREFIX)/bin/scythe
 ifeq ($(UNAME), Linux)
-	rm -f $(DESTDIR)/etc/udev/rules.d/19-footswitch.rules
+	rm -f $(DESTDIR)$(UDEVPREFIX)/rules.d/19-footswitch.rules
 endif
 
 clean:

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 PREFIX = /usr/local
-INSTALL = /usr/bin/install -c
-INSTALLDATA = /usr/bin/install -c -m 644
+INSTALL = /usr/bin/install -cD
+INSTALLDATA = /usr/bin/install -cD -m 644
 CFLAGS = -Wall
 UNAME := $(shell uname)
 ifeq ($(UNAME), Darwin)

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,9 @@
-PREFIX = /usr/local
+# PREFIX = /usr/local
+PREFIX = /usr
+# UDEVPREFIX = /etc/udev
+UDEVPREFIX = /lib/udev
+
+
 INSTALL = /usr/bin/install -c
 INSTALLDATA = /usr/bin/install -c -m 644
 CFLAGS = -Wall
@@ -26,7 +31,7 @@ install: all
 	$(INSTALL) scythe $(DESTDIR)$(PREFIX)/bin
 ifeq ($(UNAME), Linux)
 	$(INSTALL) -d $(DESTDIR)/etc/udev/rules.d
-	$(INSTALLDATA) 19-footswitch.rules $(DESTDIR)/etc/udev/rules.d
+	$(INSTALLDATA) 19-footswitch.rules $(DESTDIR)$(UDEVPREFIX)/rules.d
 endif
 
 uninstall:

--- a/Makefile
+++ b/Makefile
@@ -21,17 +21,17 @@ footswitch: footswitch.c common.c debug.c
 scythe: scythe.c common.c debug.c
 
 install: all
-	$(INSTALL) footswitch $(PREFIX)/bin
-	$(INSTALL) scythe $(PREFIX)/bin
+	$(INSTALL) footswitch $(DESTDIR)$(PREFIX)/bin
+	$(INSTALL) scythe $(DESTDIR)$(PREFIX)/bin
 ifeq ($(UNAME), Linux)
-	$(INSTALLDATA) 19-footswitch.rules /etc/udev/rules.d
+	$(INSTALLDATA) 19-footswitch.rules $(DESTDIR)/etc/udev/rules.d
 endif
 
 uninstall: 
-	rm -f $(PREFIX)/bin/footswitch
-	rm -f $(PREFIX)/bin/scythe
+	rm -f $(DESTDIR)$(PREFIX)/bin/footswitch
+	rm -f $(DESTDIR)$(PREFIX)/bin/scythe
 ifeq ($(UNAME), Linux)
-	rm -f /etc/udev/rules.d/19-footswitch.rules
+	rm -f $(DESTDIR)/etc/udev/rules.d/19-footswitch.rules
 endif
 
 clean:

--- a/Makefile
+++ b/Makefile
@@ -30,7 +30,7 @@ install: all
 	$(INSTALL) footswitch $(DESTDIR)$(PREFIX)/bin
 	$(INSTALL) scythe $(DESTDIR)$(PREFIX)/bin
 ifeq ($(UNAME), Linux)
-	$(INSTALL) -d $(DESTDIR)/etc/udev/rules.d
+	$(INSTALL) -d $(DESTDIR)$(UDEVPREFIX)/rules.d
 	$(INSTALLDATA) 19-footswitch.rules $(DESTDIR)$(UDEVPREFIX)/rules.d
 endif
 


### PR DESCRIPTION
Tweaked the Makefile to permit specifying a DESTDIR for staged install, which is required to create packages. Changes are as follows.

1. Modified install commands to include a DESTDIR variable.
2. Ensured a path is created, when not present, before installing files.
3. Set a variable containing the final installation patch, to facilitate patching according to distribution guidelines.

The Makefile works well with the Gentoo [ebuild](https://github.com/aureliocarlucci/AurOverlay/blob/master/app-misc/footswitch/footswitch-9999.ebuild) i wrote.