### PR TITLE
Add scythe2 to install and uninstall sections of Makefile and gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 *.swp
 # binaries
 scythe
+scythe2
 footswitch

--- a/Makefile
+++ b/Makefile
@@ -27,6 +27,7 @@ install: all
 	$(INSTALL) -d $(DESTDIR)$(PREFIX)/bin
 	$(INSTALL) footswitch $(DESTDIR)$(PREFIX)/bin
 	$(INSTALL) scythe $(DESTDIR)$(PREFIX)/bin
+	$(INSTALL) scythe2 $(DESTDIR)$(PREFIX)/bin
 ifeq ($(UNAME), Linux)
 	$(INSTALL) -d $(DESTDIR)$(UDEVPREFIX)/rules.d
 	$(INSTALLDATA) 19-footswitch.rules $(DESTDIR)$(UDEVPREFIX)/rules.d
@@ -35,6 +36,7 @@ endif
 uninstall:
 	rm -f $(DESTDIR)$(PREFIX)/bin/footswitch
 	rm -f $(DESTDIR)$(PREFIX)/bin/scythe
+	rm -f $(DESTDIR)$(PREFIX)/bin/scythe2
 ifeq ($(UNAME), Linux)
 	rm -f $(DESTDIR)$(UDEVPREFIX)/rules.d/19-footswitch.rules
 endif


### PR DESCRIPTION
Add scythe2 to install and uninstall sections of Makefile and to .gitignore.
Now `sudo make install` and `sudo make uninstall` include this binary.
See issue #85.