### PR TITLE
Add support for PCsensor 3553:b001

### DIFF
--- a/19-footswitch.rules
+++ b/19-footswitch.rules
@@ -3,6 +3,7 @@ SUBSYSTEMS=="usb", ATTRS{idVendor}=="0c45", ATTRS{idProduct}=="7403", TAG+="uacc
 SUBSYSTEMS=="usb", ATTRS{idVendor}=="0c45", ATTRS{idProduct}=="7404", TAG+="uaccess"
 SUBSYSTEMS=="usb", ATTRS{idVendor}=="413d", ATTRS{idProduct}=="2107", TAG+="uaccess"
 SUBSYSTEMS=="usb", ATTRS{idVendor}=="1a86", ATTRS{idProduct}=="e026", TAG+="uaccess"
+SUBSYSTEMS=="usb", ATTRS{idVendor}=="3553", ATTRS{idProduct}=="b001", TAG+="uaccess"
 # Scythe
 SUBSYSTEMS=="usb", ATTRS{idVendor}=="0426", ATTRS{idProduct}=="3011", TAG+="uaccess"
 # Scythe2

--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ The following list of devices are supported:
 | 0c45     | 7404      | `footswitch`  |
 | 413d     | 2107      | `footswitch`  |
 | 1a86     | e026      | `footswitch`  |
+| 3553     | b001      | `footswitch`  |
 | 0426     | 3011      | `scythe`      |
 | 055a     | 0998      | `scythe2`     |
 

--- a/footswitch.c
+++ b/footswitch.c
@@ -98,6 +98,7 @@ void init() {
         {0x0c45, 0x7404},
         {0x413d, 0x2107},
         {0x1a86, 0xe026},
+        {0x3553, 0xb001},
     };
     int i = 0;
     for (i = 0 ; i < sizeof(vid_pid) / sizeof(vid_pid[0]) ; i++) {


### PR DESCRIPTION
I have added support for another PCsensor foot switch:
https://pcsensor.com/product-details?product_id=1017

I have successfully compiled the modified source code and tested the binary on this device.
Thank you for this project!