### PR TITLE
Add support for multiple devices

### DIFF
--- a/footswitch.c
+++ b/footswitch.c
@@ -74,10 +74,10 @@ void usage() {
 }
 
 void init_pid(unsigned short vid, unsigned short pid, int* pedal_index) {
-#ifdef OSX
-    hid_init();
-    dev = hid_open(vid, pid, NULL);
-#else
+// #ifdef OSX
+//     hid_init();
+//     dev = hid_open(vid, pid, NULL);
+// #else
     struct hid_device_info *info = NULL, *ptr = NULL;
     hid_init();
     info = hid_enumerate(vid, pid);
@@ -94,7 +94,7 @@ void init_pid(unsigned short vid, unsigned short pid, int* pedal_index) {
         ptr = ptr->next;
     }
     hid_free_enumeration(info);
-#endif
+// #endif
 }
 
 void init(int pedal_index) {


### PR DESCRIPTION
Pull Request https://github.com/rgerganov/footswitch/pull/68 has been rebased to support latest sensors and the #ifdef for OSX has been removed to add support for multiple devices for OSX too.

Note that I've noticed some bug in the implementation of @taladar as the key mapping has to be done in ascending order of `-k`, elsewhise some assignement is overwritten.

@rgerganov it reverts the preprocessor distinguishing the OSes in libhdi but it works well this way for me. Test it also maybe.

Please note that I'm not a C developer and I've just tried to make it work enough for me.