### PR TITLE
feat: add MK321U support

### DIFF
--- a/19-footswitch.rules
+++ b/19-footswitch.rules
@@ -4,6 +4,7 @@ SUBSYSTEMS=="usb", ATTRS{idVendor}=="0c45", ATTRS{idProduct}=="7404", TAG+="uacc
 SUBSYSTEMS=="usb", ATTRS{idVendor}=="413d", ATTRS{idProduct}=="2107", TAG+="uaccess"
 SUBSYSTEMS=="usb", ATTRS{idVendor}=="1a86", ATTRS{idProduct}=="e026", TAG+="uaccess"
 SUBSYSTEMS=="usb", ATTRS{idVendor}=="3553", ATTRS{idProduct}=="b001", TAG+="uaccess"
+SUBSYSTEMS=="usb", ATTRS{idVendor}=="3553", ATTRS{idProduct}=="c010", TAG+="uaccess"
 # Scythe
 SUBSYSTEMS=="usb", ATTRS{idVendor}=="0426", ATTRS{idProduct}=="3011", TAG+="uaccess"
 # Scythe2

--- a/debian/footswitch.udev
+++ b/debian/footswitch.udev
@@ -4,6 +4,7 @@ SUBSYSTEMS=="usb", ATTRS{idVendor}=="0c45", ATTRS{idProduct}=="7404", MODE="0666
 SUBSYSTEMS=="usb", ATTRS{idVendor}=="413d", ATTRS{idProduct}=="2107", MODE="0666"
 SUBSYSTEMS=="usb", ATTRS{idVendor}=="1a86", ATTRS{idProduct}=="e026", MODE="0666"
 SUBSYSTEMS=="usb", ATTRS{idVendor}=="3553", ATTRS{idProduct}=="b001", MODE="0666"
+SUBSYSTEMS=="usb", ATTRS{idVendor}=="3553", ATTRS{idProduct}=="c010", MODE="0666"
 
 # Scythe
 SUBSYSTEMS=="usb", ATTRS{idVendor}=="0426", ATTRS{idProduct}=="3011", MODE="0666"

--- a/src/footswitch.c
+++ b/src/footswitch.c
@@ -99,6 +99,7 @@ void init() {
         {0x413d, 0x2107},
         {0x1a86, 0xe026},
         {0x3553, 0xb001},
+        {0x3553, 0xc010},
     };
     int i = 0;
     for (i = 0 ; i < sizeof(vid_pid) / sizeof(vid_pid[0]) ; i++) {


### PR DESCRIPTION
I've recently bought a PCsensor 3-key mini-keyboard from Amazon (ASIN: B0BDRPQLW1), which back sticker indicates `MK321U`. The device appears as follows in `lsusb`:

```
Bus 001 Device 013: ID 3553:c010 PCsensor DIY keyboard
```
and `dmesg`:

```
[ 4565.182868] usb 1-10: new full-speed USB device number 14 using xhci_hcd
[ 4565.464589] usb 1-10: New USB device found, idVendor=3553, idProduct=c010, bcdDevice= 1.00
[ 4565.464594] usb 1-10: New USB device strings: Mfr=1, Product=2, SerialNumber=0
[ 4565.464596] usb 1-10: Product: DIY keyboard
[ 4565.464597] usb 1-10: Manufacturer: PCsensor
[ 4565.514834] input: PCsensor DIY keyboard Keyboard as /devices/pci0000:00/0000:00:01.2/0000:02:00.0/usb1/1-10/1-10:1.0/0003:3553:C010.001B/input/input64
[ 4565.570990] input: PCsensor DIY keyboard Mouse as /devices/pci0000:00/0000:00:01.2/0000:02:00.0/usb1/1-10/1-10:1.0/0003:3553:C010.001B/input/input65
[ 4565.571054] hid-generic 0003:3553:C010.001B: input,hidraw11: USB HID v1.11 Keyboard [PCsensor DIY keyboard] on usb-0000:02:00.0-10/input0
[ 4565.579692] input: PCsensor DIY keyboard as /devices/pci0000:00/0000:00:01.2/0000:02:00.0/usb1/1-10/1-10:1.1/0003:3553:C010.001C/input/input66
[ 4565.579744] hid-generic 0003:3553:C010.001C: input,hidraw12: USB HID v1.10 Device [PCsensor DIY keyboard] on usb-0000:02:00.0-10/input1
[ 4565.607758] input: PCsensor DIY keyboard Keyboard as /devices/pci0000:00/0000:00:01.2/0000:02:00.0/usb1/1-10/1-10:1.2/0003:3553:C010.001D/input/input67
[ 4565.670933] input: PCsensor DIY keyboard as /devices/pci0000:00/0000:00:01.2/0000:02:00.0/usb1/1-10/1-10:1.2/0003:3553:C010.001D/input/input69
[ 4565.671006] hid-multitouch 0003:3553:C010.001D: input,hidraw13: USB HID v1.10 Keyboard [PCsensor DIY keyboard] on usb-0000:02:00.0-10/input2
```

I've tried adding the `VID:PID` combination to the appropriate source files, but the output hangs indefinitely on `footswitch -r`, and succeeds on write operation such as (I uncommented debug output in `write_pedals`):

```
> footswitch -1 -k s -2 -k x -3 -k e
start: 01 80 08 00 00 00 00 00
pedal 1 header: 01 81 08 01 00 00 00 00
pedal 1 data: 08 01 00 16 00 00 00 00
pedal 2 header: 01 81 08 02 00 00 00 00
pedal 2 data: 08 01 00 1b 00 00 00 00
pedal 3 header: 01 81 08 03 00 00 00 00
pedal 3 data: 08 01 00 08 00 00 00 00
```
The values are correctly written, however, it seems to have no effect, as the keys are still producing the default output. I suspect the data structure is different from older models, but I'm not well-versed in HID interfaces to explore to find out what is wrong. Would you have any pointers?

Thanks!