### PR TITLE
Fixing brew build

### DIFF
--- a/HomebrewFormula/footswitch.rb
+++ b/HomebrewFormula/footswitch.rb
@@ -5,6 +5,7 @@ class Footswitch < Formula
   head "https://github.com/rgerganov/footswitch.git"
 
   depends_on "hidapi"
+  depends_on "pkg-config"
 
   def install
     system "mkdir", "#{prefix}/bin"


### PR DESCRIPTION
`pkg-config` isn't default on macos